### PR TITLE
DC-153 parse url testnet or mainnet and redirect configuration

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -18,6 +18,9 @@ import SingleBlockPage from './blocks/SingleBlockPage';
 import SingleTransactionPage from './transactions/SingleTransactionPage';
 import SingleAddressPage from './addresses/SingleAddressPage';
 import SingleAliasPage from './aliases/SingleAliasPage';
+import { redirectService } from './services/RedirectService';
+
+
 
 class App extends React.Component {
     state = {
@@ -27,6 +30,11 @@ class App extends React.Component {
     handleMobileMenuToggle = () => {
         this.setState({mobileMenuVisible: !this.state.mobileMenuVisible});
     };
+
+    componentDidMount() {
+        const {networkId, newPathname} = redirectService.parseUrl();
+        redirectService.switchNetwork(networkId, newPathname);
+    }
 
     render() {
         const isVisible = this.state.mobileMenuVisible;
@@ -52,7 +60,7 @@ class App extends React.Component {
                             <Route exact path={routes.transactions.one(routeParams.transactionId)} component={SingleTransactionPage} />
                             <Route exact path={routes.addresses.one(routeParams.address)} component={SingleAddressPage} />
                             <Route exact path={routes.aliases.one(routeParams.alias)} component={SingleAliasPage} />
-                            <Route path={routes.root} component={MainPage} /> 
+                            <Route path={routes.root} component={MainPage} />
                         </Switch>
                         </div>
                     </div>

--- a/src/App.js
+++ b/src/App.js
@@ -20,8 +20,6 @@ import SingleAddressPage from './addresses/SingleAddressPage';
 import SingleAliasPage from './aliases/SingleAliasPage';
 import { redirectService } from './services/RedirectService';
 
-
-
 class App extends React.Component {
     state = {
         mobileMenuVisible: null

--- a/src/aliases/SingleAliasPage.js
+++ b/src/aliases/SingleAliasPage.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import {Redirect} from 'react-router-dom';
 
-import {routeBuilder} from '../shared/Routing';
+import {routes} from '../shared/Routing';
 import ServiceFactory from '../services/ServiceFactory';
 
 import Loader from '../shared/Loader';

--- a/src/aliases/SingleAliasPage.js
+++ b/src/aliases/SingleAliasPage.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import {Redirect} from 'react-router-dom';
 
-import {routes} from '../shared/Routing';
+import {routeBuilder} from '../shared/Routing';
 import ServiceFactory from '../services/ServiceFactory';
 
 import Loader from '../shared/Loader';

--- a/src/services/RedirectService.js
+++ b/src/services/RedirectService.js
@@ -2,7 +2,7 @@ import ServiceFactory from './ServiceFactory';
 
 class RedirectService{
     redirectOnHome = (newPath) => {
-        window.location.href = newPath ? newPath : '';
+        window.location.href = newPath || '';
     }
 
     switchNetwork = (networkId, newPath) => {

--- a/src/services/RedirectService.js
+++ b/src/services/RedirectService.js
@@ -2,11 +2,7 @@ import ServiceFactory from './ServiceFactory';
 
 class RedirectService{
     redirectOnHome = (newPath) => {
-        if(newPath){
-            window.location.href = newPath;
-        }else{
-            window.location.href = '';
-        }
+        window.location.href = newPath ? newPath : '';
     }
 
     switchNetwork = (networkId, newPath) => {
@@ -27,7 +23,7 @@ class RedirectService{
                     newPathname += '';
                 }else{
                     newPathname += pathArray[i];
-                    newPathname += (i != pathArray.length - 1) ?'/': '';
+                    newPathname += (i != pathArray.length - 1) ? '/' : '';
                 }
             }
         }

--- a/src/services/RedirectService.js
+++ b/src/services/RedirectService.js
@@ -1,0 +1,39 @@
+import ServiceFactory from '../services/ServiceFactory';
+
+class RedirectService{
+    redirectOnHome = (newPath) => {
+        if(newPath){
+            window.location.href = newPath;
+        }else{
+            window.location.href = '';
+        }
+    }
+
+    switchNetwork = (networkId, newPath) => {
+        if(networkId){
+            ServiceFactory.configurationService().select(networkId);
+            this.redirectOnHome(newPath);
+        }
+    };
+
+    parseUrl = () => {
+        const pathArray = window.location.pathname.split('/');
+        var networkId = null;
+        var newPathname = "";
+        if(pathArray && pathArray[1] != '') {
+            for (let i = 0; i < pathArray.length; i++) {
+                if (pathArray[i] == 'testnet' || pathArray[i] == 'mainnet') {
+                    networkId = pathArray[1];
+                    newPathname += '';
+                }else{
+                    newPathname += pathArray[i];
+                    newPathname += (i != pathArray.length - 1) ?'/': '';
+                }
+            }
+        }
+        // console.log(networkId, newPathname);
+        return {networkId, newPathname}
+    }
+}
+const redirectService = new RedirectService();
+export { redirectService };

--- a/src/services/RedirectService.js
+++ b/src/services/RedirectService.js
@@ -1,4 +1,4 @@
-import ServiceFactory from '../services/ServiceFactory';
+import ServiceFactory from './ServiceFactory';
 
 class RedirectService{
     redirectOnHome = (newPath) => {
@@ -18,8 +18,8 @@ class RedirectService{
 
     parseUrl = () => {
         const pathArray = window.location.pathname.split('/');
-        var networkId = null;
-        var newPathname = "";
+        let networkId = null;
+        let newPathname = "";
         if(pathArray && pathArray[1] != '') {
             for (let i = 0; i < pathArray.length; i++) {
                 if (pathArray[i] == 'testnet' || pathArray[i] == 'mainnet') {

--- a/src/services/RedirectService.js
+++ b/src/services/RedirectService.js
@@ -31,7 +31,6 @@ class RedirectService{
                 }
             }
         }
-        // console.log(networkId, newPathname);
         return {networkId, newPathname}
     }
 }

--- a/src/services/RedirectService.js
+++ b/src/services/RedirectService.js
@@ -20,7 +20,7 @@ class RedirectService{
         const pathArray = window.location.pathname.split('/');
         let networkId = null;
         let newPathname = "";
-        if(pathArray && pathArray[1] != '') {
+        if(pathArray[1] != '') {
             for (let i = 0; i < pathArray.length; i++) {
                 if (pathArray[i] == 'testnet' || pathArray[i] == 'mainnet') {
                     networkId = pathArray[1];


### PR DESCRIPTION
Depending on what address you entered in the url, the redirect service parse it and redirect to the necessary configuration testnet or mainnet. Examples url: ```explorer.acrylplatform.com/testnet/faucet => explorer.acrylplatform.com/faucet and configuration network = testnet```